### PR TITLE
add eulalink to metadata file

### DIFF
--- a/Packs/Code42/pack_metadata.json
+++ b/Packs/Code42/pack_metadata.json
@@ -14,6 +14,7 @@
     "tags": [],
     "useCases": [],
     "keywords": [],
+    "eulaLink": "https://support.code42.com/Terms_and_conditions/Legal_terms_and_conditions/Master_services_agreement",
     "githubUser": [
         "nathanhunstad"
     ]


### PR DESCRIPTION
Added `eulaLink` field to the `pack_metadata.json` file.
